### PR TITLE
feat: Add Signal macro for creating signals and emit functions

### DIFF
--- a/Macros/Signal.gd
+++ b/Macros/Signal.gd
@@ -24,13 +24,14 @@ static func apply_macro(line_data: MagicMacrosLineData) -> String:
 	identifiers = line_data.identifier_args.duplicate()
 	types = line_data.type_args.duplicate()
 	
+	var signal_name: String = identifiers[0]
 	var method_parameters: String = create_parameters(true)
 	var passed_in_parameters = create_parameters(false)
 	
-	s  = "signal %s" % identifiers[0]
+	s  = "signal %s" % signal_name
 	s += "(%s)\n\n" % method_parameters if !method_parameters.is_empty() else "\n\n"
-	s += "func emit_%s(%s) -> void:\n" % [identifiers[0], method_parameters]
-	s += "	%s.emit(%s)\n" %  [identifiers[0], passed_in_parameters]
+	s += "func emit_%s(%s) -> void:\n" % [signal_name, method_parameters]
+	s += "	%s.emit(%s)\n" %  [signal_name, passed_in_parameters]
 	
 	return s
 

--- a/Macros/Signal.gd
+++ b/Macros/Signal.gd
@@ -27,7 +27,8 @@ static func apply_macro(line_data: MagicMacrosLineData) -> String:
 	var method_parameters: String = create_parameters(true)
 	var passed_in_parameters = create_parameters(false)
 	
-	s  = "signal %s(%s)\n\n" % [identifiers[0], method_parameters]
+	s  = "signal %s\n\n" % identifiers[0]
+	s += "(%s)" % method_parameters if !method_parameters.is_empty() else ""
 	s += "func emit_%s(%s) -> void:\n" % [identifiers[0], method_parameters]
 	s += "	%s.emit(%s)\n" %  [identifiers[0], passed_in_parameters]
 	

--- a/Macros/Signal.gd
+++ b/Macros/Signal.gd
@@ -27,8 +27,8 @@ static func apply_macro(line_data: MagicMacrosLineData) -> String:
 	var method_parameters: String = create_parameters(true)
 	var passed_in_parameters = create_parameters(false)
 	
-	s  = "signal %s\n\n" % identifiers[0]
-	s += "(%s)" % method_parameters if !method_parameters.is_empty() else ""
+	s  = "signal %s" % identifiers[0]
+	s += "(%s)\n\n" % method_parameters if !method_parameters.is_empty() else "\n\n"
 	s += "func emit_%s(%s) -> void:\n" % [identifiers[0], method_parameters]
 	s += "	%s.emit(%s)\n" %  [identifiers[0], passed_in_parameters]
 	

--- a/Macros/Signal.gd
+++ b/Macros/Signal.gd
@@ -1,0 +1,50 @@
+# Example
+# sig on_test one two int Type.EnumName
+#
+# signal on_test(one: int, two: Type.EnumName)
+#
+# func emit_on_test(one: int, two: Type.EnumName) -> void:
+#	 on_test.emit(one, two)
+
+@tool
+extends MagicMacrosMacro
+
+const ALIASES: Array[String] = ["sig"]
+
+static var s: String
+static var identifiers: Array[String]
+static var types: Array[String]
+
+
+static func is_macro_alias(arg: String) -> bool:
+	return arg in ALIASES
+
+
+static func apply_macro(line_data: MagicMacrosLineData) -> String:
+	identifiers = line_data.identifier_args.duplicate()
+	types = line_data.type_args.duplicate()
+	
+	var method_parameters: String = create_parameters(true)
+	var passed_in_parameters = create_parameters(false)
+	
+	s  = "signal %s(%s)\n\n" % [identifiers[0], method_parameters]
+	s += "func emit_%s(%s) -> void:\n" % [identifiers[0], method_parameters]
+	s += "	%s.emit(%s)\n" %  [identifiers[0], passed_in_parameters]
+	
+	return s
+
+
+static func create_parameters(method_signature: bool) -> String:
+	var parameters: String = ""
+	var template: String = "%s: %s" if method_signature else "%s"
+	
+	for i in types.size():
+		if method_signature:
+			parameters += template % [identifiers[i + 1], types[i]]
+		else:
+			parameters += template % identifiers[i + 1]
+			
+		if i < types.size() - 1:
+			parameters += ", "
+	
+	return parameters

--- a/Macros/Signal.gd.uid
+++ b/Macros/Signal.gd.uid
@@ -1,0 +1,1 @@
+uid://crmbvtdtpwdp1

--- a/MagicMacros.gd
+++ b/MagicMacros.gd
@@ -8,7 +8,13 @@ const THEME_COLOR_CONSTANT: String = "current_line_color"
 # Color with which to highlight a valid macro with
 const THEME_COLOR_VALID: Color = Color(0.0, 1.0, 0.0, 0.15)
 # regex patterns used for argument detection. See LineData
-const PASCAL_CASE_REGEX_PATTERN: String = '^[A-Z][a-zA-Z0-9]*$'
+# Captures following PascalCase type combinations
+# Test
+# Test2
+# Test.Test
+# Test1.Test
+# Test1.Test2.Test.Test.Test...
+const PASCAL_CASE_REGEX_PATTERN: String = '^[A-Z][A-Za-z0-9]*(\\.[A-Z][A-Za-z0-9]*)*?$'
 const SNAKE_CASE_REGEX_PATTERN: String = '^[a-z0-9_]+$'
 
 var pascal_case_regex: RegEx

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Alternatively, download the zip from this page and unpack it into your addons fo
 * ready | rdy = creates the _ready function.
 * fn | fnc = creates a function with specified name and return type if any.
 * node = creates an @onready variable with specified name, type, value if any.
+* tw = create a tween variable
+* sig = creates a signal with specified name and parameters, creates an emit function
 
 ---
 


### PR DESCRIPTION
Added a signal macro

Example
`sig no_params`
```gdscript
signal no_params

func emit_no_params() -> void:
	no_params.emit()
```

`sig on_test one two int Type.EnumName`
```gdscript
signal on_test(one: int, two: Type.EnumName)

func emit_on_test(one: int, two: Type.EnumName) -> void:
    on_test.emit(one, two)
```

